### PR TITLE
A-Assertions: add assertion to parse command check

### DIFF
--- a/src/main/java/duke/parser/Parser.java
+++ b/src/main/java/duke/parser/Parser.java
@@ -95,6 +95,7 @@ public class Parser {
         case BYE:
             return new ExitCommand();
         default:
+            assert false: "Should not reach here since unknown command exception is handled.";
             throw new UnknownCommandException();
         }
     }


### PR DESCRIPTION
Default case in `Parser` is not reachable since there is a prior check to `UnknownCommandException`

Add assert to the default case.

This is to detect any error if the program happens to reach the default case.
